### PR TITLE
Allow using correct max amount of relics

### DIFF
--- a/src/main/java/com/robertx22/dungeon_realm/block_entity/MapDeviceBE.java
+++ b/src/main/java/com/robertx22/dungeon_realm/block_entity/MapDeviceBE.java
@@ -65,7 +65,7 @@ public class MapDeviceBE extends BlockEntity implements ContainerListener {
                     var data = DungeonItemNbt.RELIC.loadFrom(stack);
                     int cur = map.getOrDefault(data.type, 0) + 1;
                     map.put(data.type, cur);
-                    if (cur < data.getType().max_equipped) {
+                    if (cur <= data.getType().max_equipped) {
                         all.add(data);
                     } else {
                         int a = 5;


### PR DESCRIPTION
Usually when it says `max` it means less or equal, so following this idea here as well

And you also use this behaviour when allowing player to add relics - https://github.com/RobertSkalko/dungeon_realm/blob/main/src/main/java/com/robertx22/dungeon_realm/block_entity/MapDeviceMenu.java#L137